### PR TITLE
Closing fix

### DIFF
--- a/Aggregator/aggregator.py
+++ b/Aggregator/aggregator.py
@@ -45,7 +45,7 @@ async def aggregate(
         to=to,
         limit=limit,
         prefetch_size=prefetch_size,
-        max_retries=max_retries,
+        max_retry=max_retries,
         sleep_step=sleep_step,
     ) as aggregator:
         try:

--- a/Aggregator/errors.py
+++ b/Aggregator/errors.py
@@ -7,7 +7,7 @@ class PageResponseError(BaseException):
         cdx_server: str,
         *args: object,
         page: int = 0,
-        retries: int = 0
+        retry: int = 0
     ) -> None:
         super().__init__(*args)
         self.domain = domain
@@ -15,7 +15,7 @@ class PageResponseError(BaseException):
         self.cdx_server = cdx_server
         self.status = status
         self.reason = reason
-        self.retires = retries
+        self.retry = retry
 
 
 class LimitError(BaseException):

--- a/Aggregator/tests/aggregator_tests.py
+++ b/Aggregator/tests/aggregator_tests.py
@@ -1,14 +1,17 @@
 from datetime import datetime
+import logging
 from typing import List
 from index_query import DomainRecord, IndexAggregator
 import unittest
+
+logging.basicConfig(level=logging.DEBUG)
 
 
 class TestIndexerAsync(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         self.CC_SERVERS = ["https://index.commoncrawl.org/CC-MAIN-2022-05-index"]
         self.di = await IndexAggregator(
-            ["idnes.cz"], cc_servers=self.CC_SERVERS, max_retries=50
+            ["idnes.cz"], cc_servers=self.CC_SERVERS, max_retry=50
         ).aopen()
         self.client = self.di.client
 
@@ -92,6 +95,15 @@ class TestIndexerAsync(unittest.IsolatedAsyncioTestCase):
 
         # Checked by alternative client
         self.assertEqual(len(records), 194393)
+
+    async def test_cancel_iterator_tasks(self):
+        self.di.limit = 10
+        async for record in self.di:
+            pass
+        await self.di.aclose(None, None, None)
+        for iterator in self.di.iterators:
+            for task in iterator.prefetch_queue:
+                self.assertTrue(task.cancelled() or task.done())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Iterators are closed properly when context manager is exited.